### PR TITLE
Fix code scanning alert no. 6: Insecure randomness

### DIFF
--- a/api/src/main/java/org/openmrs/migration/MigrationHelper.java
+++ b/api/src/main/java/org/openmrs/migration/MigrationHelper.java
@@ -21,7 +21,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.security.SecureRandom;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -128,7 +128,7 @@ public class MigrationHelper {
 	@Deprecated
 	public static int importUsers(Document document) throws ParseException {
 		int ret = 0;
-		Random rand = new Random();
+		SecureRandom rand = new SecureRandom();
 		UserService us = Context.getUserService();
 		
 		List<Node> toAdd = new ArrayList<>();


### PR DESCRIPTION
Fixes [https://github.com/shambat/openmrs-core/security/code-scanning/6](https://github.com/shambat/openmrs-core/security/code-scanning/6)

To fix the problem, we need to replace the use of `java.util.Random` with `java.security.SecureRandom`. This change ensures that the random values generated for passwords are cryptographically secure and not easily predictable.

- Replace the instantiation of `Random` with `SecureRandom`.
- Update the code to use `SecureRandom` for generating random integers and bytes.
- Ensure that the functionality remains the same, i.e., generating a password of 8-12 random characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
